### PR TITLE
Fixed readyness probe for the mailcatcher template

### DIFF
--- a/mailcatcher/mailcatcher.yaml
+++ b/mailcatcher/mailcatcher.yaml
@@ -94,6 +94,7 @@ objects:
             exec:
               command:
               - /usr/bin/pgrep
+              - -f
               - mailcatcher
             initialDelaySeconds: 5
             timeoutSeconds: 1


### PR DESCRIPTION
Currently the readyness probe is failing for this template because it's only trying to match the /usr/local/bin/ruby bit of the command, with the added "-f" flag it will match against the full command that includes the "mailcatcher" command.